### PR TITLE
Change this.state.index to null instead of zero.

### DIFF
--- a/src/pages/PrebuiltQuiz.js
+++ b/src/pages/PrebuiltQuiz.js
@@ -16,7 +16,7 @@ export default class PrebuiltQuiz extends React.Component {
       wrong3: '',
       questions: [],
       answers: [],
-      index: 0,
+      index: null,
       timeCount:60,
       correctAns: 0, // number of correct and wrong answer submissions
       wrongAns: 0,


### PR DESCRIPTION
Initialize this.state.index on prebuiltquiz to null so that handleEndQuiz is not called upon page load.